### PR TITLE
FIX: Vars should be empty by default not "None"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,6 @@ openldap_schmas:
   - inetorgperson
   - nis
 
-openldap_tls_cert:
-openldap_tls_key:
-openldap_tls_cacert:
+openldap_tls_cert: ""
+openldap_tls_key: ""
+openldap_tls_cacert: ""


### PR DESCRIPTION
This fixes a small bug, if no Certificate is defined, the Variables were `None` not empty.